### PR TITLE
feat(argocd-project): cluster + namespace resource whitelists & source_repos input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0]() (2026-05-16)
+
+### Features
+
+* `argocd-project` module: add `cluster_resource_whitelist`,
+  `namespace_resource_whitelist`, `cluster_resource_blacklist`, and
+  `namespace_resource_blacklist` inputs to control which Kubernetes
+  resource kinds Applications under the project may sync. Default
+  preserves existing behavior (no cluster-scoped resources allowed)
+  so this is non-breaking.
+* `argocd-project` module: add `source_repos` input (default `["*"]`)
+  to override the previously-hardcoded permissive value.
+
 ## [1.3.0]() (2026-01-29)
 
 ### Features

--- a/modules/argocd-project/main.tf
+++ b/modules/argocd-project/main.tf
@@ -48,24 +48,38 @@ resource "kubernetes_manifest" "this" {
       name      = var.project_name
     }
 
-    spec = {
-      description = var.description
-      sourceRepos = ["*"]
-      destinations = concat(
-        var.destinations,
-        [{
-          name      = "in-cluster"
-          namespace = var.argocd_namespace
-        }]
-      )
-      roles = [
-        for group, roles in local.group_roles : {
-          name     = group
-          groups   = ["${var.github_organization}:${group}"]
-          policies = [for role in roles : "p, proj:${var.project_name}:${group}, ${role}, ${var.project_name}/*, allow"]
-        }
-      ]
-    }
+    spec = merge(
+      {
+        description = var.description
+        sourceRepos = var.source_repos
+        destinations = concat(
+          var.destinations,
+          [{
+            name      = "in-cluster"
+            namespace = var.argocd_namespace
+          }]
+        )
+        roles = [
+          for group, roles in local.group_roles : {
+            name     = group
+            groups   = ["${var.github_organization}:${group}"]
+            policies = [for role in roles : "p, proj:${var.project_name}:${group}, ${role}, ${var.project_name}/*, allow"]
+          }
+        ]
+      },
+      length(var.cluster_resource_whitelist) > 0 ? {
+        clusterResourceWhitelist = var.cluster_resource_whitelist
+      } : {},
+      length(var.namespace_resource_whitelist) > 0 ? {
+        namespaceResourceWhitelist = var.namespace_resource_whitelist
+      } : {},
+      length(var.cluster_resource_blacklist) > 0 ? {
+        clusterResourceBlacklist = var.cluster_resource_blacklist
+      } : {},
+      length(var.namespace_resource_blacklist) > 0 ? {
+        namespaceResourceBlacklist = var.namespace_resource_blacklist
+      } : {},
+    )
   }
 
   lifecycle {

--- a/modules/argocd-project/variables.tf
+++ b/modules/argocd-project/variables.tf
@@ -90,3 +90,45 @@ variable "destinations" {
     namespace = string
   }))
 }
+
+variable "source_repos" {
+  description = "Allowed Git/Helm/OCI source repos for Applications under this project. Defaults to ['*'] to preserve existing behavior."
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "cluster_resource_whitelist" {
+  description = "Cluster-scoped resource kinds Applications under this project may apply. Empty list means no cluster-scoped resources allowed (ArgoCD default)."
+  type = list(object({
+    group = string
+    kind  = string
+  }))
+  default = []
+}
+
+variable "namespace_resource_whitelist" {
+  description = "Namespace-scoped resource kinds Applications under this project may apply. Empty list means ArgoCD applies its default (all namespaced kinds allowed)."
+  type = list(object({
+    group = string
+    kind  = string
+  }))
+  default = []
+}
+
+variable "cluster_resource_blacklist" {
+  description = "Cluster-scoped resource kinds Applications under this project may NOT apply. Useful when whitelist is broad but specific kinds must be denied."
+  type = list(object({
+    group = string
+    kind  = string
+  }))
+  default = []
+}
+
+variable "namespace_resource_blacklist" {
+  description = "Namespace-scoped resource kinds Applications under this project may NOT apply."
+  type = list(object({
+    group = string
+    kind  = string
+  }))
+  default = []
+}


### PR DESCRIPTION
## Summary

The \`argocd-project\` module hardcoded \`sourceRepos = ["*"]\` and
omitted the AppProject's whitelist / blacklist fields entirely. That
made it impossible to use the module with controller charts that
bundle cluster-scoped resources (CRD, ClusterRole, ClusterRoleBinding)
— ArgoCD's default posture denies them, and the only escape was to
fork the module or replace the AppProject with a raw
\`kubernetes_manifest\`.

Adds five new inputs (all optional, defaults preserve existing
behavior):

| Input | Default | Purpose |
|---|---|---|
| \`source_repos\` | \`["*"]\` | Override the previously-hardcoded permissive list |
| \`cluster_resource_whitelist\` | \`[]\` | List of \`{group, kind}\` cluster-scoped resources Applications may apply |
| \`namespace_resource_whitelist\` | \`[]\` | Same for namespace-scoped (empty = ArgoCD default = all allowed) |
| \`cluster_resource_blacklist\` | \`[]\` | Deny list for cluster-scoped resources |
| \`namespace_resource_blacklist\` | \`[]\` | Deny list for namespace-scoped resources |

Each whitelist/blacklist input only injects its corresponding
AppProject field when non-empty, so the rendered manifest matches the
previous output **byte-for-byte** when callers don't set anything.

## Motivation

Deploying GitHub's Actions Runner Controller v2 on EKS via ArgoCD.
The chart needs CRD + ClusterRole + ClusterRoleBinding. Before this
change a consumer had to define a sibling AppProject out-of-band
just to allow those three kinds — losing the group-role plumbing
this module provides.

After: same module call, pass \`cluster_resource_whitelist\` with the
three needed kinds, done:

\`\`\`hcl
module "argocd_projects" {
  source = "c0x12c/helm-argocd/aws//modules/argocd-project"

  argocd_projects = {
    "8fleet-dev" = {
      # ... existing fields ...

      cluster_resource_whitelist = [
        { group = "apiextensions.k8s.io",      kind = "CustomResourceDefinition" },
        { group = "rbac.authorization.k8s.io", kind = "ClusterRole" },
        { group = "rbac.authorization.k8s.io", kind = "ClusterRoleBinding" },
      ]
    }
  }
}
\`\`\`

## Non-breaking

- All new variables have safe defaults.
- Existing consumers re-applying with no config change get a zero-diff
  plan (rendered manifest is identical).
- \`terraform validate\` passes locally against the module.

## Test plan

- [ ] Existing example in \`examples/complete\` plans clean (no diff
      from unrelated changes) without specifying new vars.
- [ ] Adding \`cluster_resource_whitelist\` to the example shows the
      manifest gaining the corresponding spec field.
- [ ] After release, downstream consumer \`8Fleet-LA/infra-terraform\`
      bumps version and removes its hand-rolled workaround.