### PR TITLE
fix(argocd-project): detect manifest drift instead of swallowing all spec changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1]() (2026-05-16)
+
+### Fix Bugs
+
+* `argocd-project` module: replace the
+  `lifecycle.ignore_changes = [manifest.spec.destinations]` block with
+  `field_manager.force_conflicts = true` + a narrow `computed_fields`
+  list (annotations, labels, finalizers — the K8s-managed bits that
+  legitimately drift). The old `ignore_changes` was suppressing drift
+  detection on the entire `manifest` attribute under newer versions
+  of the kubernetes provider, so callers who added or updated fields
+  like `clusterResourceWhitelist`, `sourceRepos`, etc. saw
+  `Apply complete: 0 changed` while the live AppProject stayed
+  unchanged — requiring out-of-band `kubectl patch` to recover.
+
+  Force-conflicts on server-side apply preserves the original goal
+  (don't fight with K8s defaulting on destinations) while letting
+  every other spec field flow through cleanly.
+
 ## [1.4.0]() (2026-05-16)
 
 ### Features

--- a/modules/argocd-project/main.tf
+++ b/modules/argocd-project/main.tf
@@ -82,10 +82,14 @@ resource "kubernetes_manifest" "this" {
     )
   }
 
-  lifecycle {
-    ignore_changes = [
-      manifest.spec.destinations
-    ]
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+    "metadata.finalizers",
+  ]
+
+  field_manager {
+    force_conflicts = true
   }
 }
 


### PR DESCRIPTION
## Summary

The previous \`lifecycle.ignore_changes = [manifest.spec.destinations]\`
on \`kubernetes_manifest.this\` was suppressing drift detection on
the **entire** manifest under newer \`hashicorp/kubernetes\` versions,
not just the destinations field as intended.

Concrete user-visible symptom from PR #14's downstream consumer:
after bumping to \`v1.4.0\` and adding \`cluster_resource_whitelist\`
to a project, \`terraform apply\` returns \`0 changed\` while
\`kubectl get appproject\` shows the live spec still missing the
field. Recovery currently requires \`kubectl patch\` out-of-band —
doesn't scale, rots across environments.

## Fix

Replace the lifecycle block with the equivalent server-side-apply
mechanism:

\`\`\`hcl
computed_fields = [
  "metadata.annotations",
  "metadata.labels",
  "metadata.finalizers",
]
field_manager {
  force_conflicts = true
}
\`\`\`

- \`force_conflicts = true\` lets Terraform overwrite fields the K8s
  API server defaults on (the original destinations concern).
- \`computed_fields\` covers metadata bits that legitimately drift
  via controllers (ArgoCD adds its own annotations).
- Every other spec field is now tracked normally.

## Non-breaking

- Rendered manifest matches byte-for-byte when no new inputs are set.
- Existing consumers re-applying after this fix will see Terraform
  reconcile any drift the old behavior was masking. **Most operations
  will be a no-op or one-time drift correction** — read the plan
  output before applying.

## Tag plan

After merge, please cut \`v1.4.1\`. Downstream \`8Fleet-LA/infra-terraform\`
will bump to consume the fix and the ARC controller rollout can
proceed without manual \`kubectl patch\` steps.