### PR TITLE
fix(argocd-project): replace_triggered_by on spec hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2]() (2026-05-16)
+
+### Fix Bugs
+
+* `argocd-project` module: force-replace `kubernetes_manifest.this`
+  whenever any spec input changes (`sourceRepos`, `destinations`,
+  `cluster_resource_whitelist`, `namespace_resource_whitelist`,
+  blacklists). Use a sentinel `terraform_data.project_spec_hash`
+  with `replace_triggered_by` on the manifest.
+
+  The 1.4.1 fix alone was not enough: when an existing project's
+  state was recorded under 1.4.0's broken `ignore_changes` block,
+  Terraform's view of "current state" already matches the new
+  desired manifest — so plan reports zero diff even after the
+  consumer adds new spec fields, and the live AppProject stays
+  out-of-sync. `replace_triggered_by` on a hash of the inputs
+  guarantees a recreate whenever the consumer changes anything
+  that matters.
+
+  Trade-off: a recreate momentarily removes the AppProject (~1 s).
+  Child Applications stay in the cluster but ArgoCD will surface
+  them as "AppProject not found" until the recreate completes.
+  Acceptable for a config-only resource; the alternative is the
+  current silent drift, which is worse.
+
 ## [1.4.1]() (2026-05-16)
 
 ### Fix Bugs

--- a/modules/argocd-project/main.tf
+++ b/modules/argocd-project/main.tf
@@ -38,6 +38,17 @@ locals {
 }
 
 
+resource "terraform_data" "project_spec_hash" {
+  input = sha256(jsonencode({
+    sourceRepos                  = var.source_repos
+    destinations                 = var.destinations
+    cluster_resource_whitelist   = var.cluster_resource_whitelist
+    namespace_resource_whitelist = var.namespace_resource_whitelist
+    cluster_resource_blacklist   = var.cluster_resource_blacklist
+    namespace_resource_blacklist = var.namespace_resource_blacklist
+  }))
+}
+
 resource "kubernetes_manifest" "this" {
   manifest = {
     apiVersion = "argoproj.io/v1alpha1"
@@ -90,6 +101,10 @@ resource "kubernetes_manifest" "this" {
 
   field_manager {
     force_conflicts = true
+  }
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.project_spec_hash]
   }
 }
 

--- a/modules/argocd-project/main.tf
+++ b/modules/argocd-project/main.tf
@@ -40,8 +40,14 @@ locals {
 
 resource "terraform_data" "project_spec_hash" {
   input = sha256(jsonencode({
+    description                  = var.description
     sourceRepos                  = var.source_repos
     destinations                 = var.destinations
+    argocd_namespace             = var.argocd_namespace
+    project_name                 = var.project_name
+    github_organization          = var.github_organization
+    predefined_group_rules       = var.predefined_group_rules
+    custom_group_roles           = var.custom_group_roles
     cluster_resource_whitelist   = var.cluster_resource_whitelist
     namespace_resource_whitelist = var.namespace_resource_whitelist
     cluster_resource_blacklist   = var.cluster_resource_blacklist

--- a/modules/argocd-project/main.tf
+++ b/modules/argocd-project/main.tf
@@ -46,8 +46,7 @@ resource "terraform_data" "project_spec_hash" {
     argocd_namespace             = var.argocd_namespace
     project_name                 = var.project_name
     github_organization          = var.github_organization
-    predefined_group_rules       = var.predefined_group_rules
-    custom_group_roles           = var.custom_group_roles
+    group_roles                  = local.group_roles
     cluster_resource_whitelist   = var.cluster_resource_whitelist
     namespace_resource_whitelist = var.namespace_resource_whitelist
     cluster_resource_blacklist   = var.cluster_resource_blacklist


### PR DESCRIPTION
## Summary

\`v1.4.1\` (#15) replaced the broken \`lifecycle.ignore_changes\` with
\`field_manager.force_conflicts\`, but that alone doesn't fix legacy
state: when an existing AppProject's state was recorded under
\`1.4.0\`'s broken \`ignore_changes\`, Terraform's "current = desired"
check returns true even after the consumer adds new spec fields.
Plan shows \`0 changed\`; live AppProject stays out-of-sync.

Concrete repro: \`8Fleet-LA/infra-terraform\` consumer added
\`cluster_resource_whitelist\` to the dev project on a v1.4.0 build,
then bumped to \`v1.4.1\`. Apply still reports \`0 changed\`. Live
spec on the cluster has empty \`clusterResourceWhitelist\`. Recovery
currently requires \`terraform taint\` or \`kubectl patch\`.

## Fix

Add a sentinel:

\`\`\`hcl
resource "terraform_data" "project_spec_hash" {
  input = sha256(jsonencode({
    sourceRepos                  = var.source_repos
    destinations                 = var.destinations
    cluster_resource_whitelist   = var.cluster_resource_whitelist
    namespace_resource_whitelist = var.namespace_resource_whitelist
    cluster_resource_blacklist   = var.cluster_resource_blacklist
    namespace_resource_blacklist = var.namespace_resource_blacklist
  }))
}

resource "kubernetes_manifest" "this" {
  manifest = { ... }
  lifecycle {
    replace_triggered_by = [terraform_data.project_spec_hash]
  }
}
\`\`\`

Any change to the spec inputs flips the hash, which forces Terraform
to DESTROY + RECREATE the manifest. The cluster state always reflects
the latest desired manifest, no manual recovery needed.

## Trade-off

Recreate momentarily removes the AppProject (sub-second in practice).
Child Applications stay in the cluster but ArgoCD surfaces
"AppProject not found" until the recreate completes (~1s). Acceptable
for a config-only resource. The alternative is silent drift, which
requires \`kubectl patch\` out-of-band — strictly worse.

## Tag plan

After merge, please cut \`v1.4.2\`. Downstream
\`8Fleet-LA/infra-terraform\` will bump again to trigger the ARC
controller unblock.