### PR TITLE
fix(argocd-project): add computed_fields + field_manager to kubernetes_manifest.app

### DIFF
--- a/modules/argocd-project/main.tf
+++ b/modules/argocd-project/main.tf
@@ -143,5 +143,17 @@ resource "kubernetes_manifest" "app" {
       syncPolicy = var.sync_policy
     }
   }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+    "metadata.finalizers",
+    "spec.operation",
+  ]
+
+  field_manager {
+    force_conflicts = true
+  }
+
   depends_on = [kubernetes_manifest.this]
 }


### PR DESCRIPTION
## Summary

\`v1.4.1\` (#15) and \`v1.4.2\` (#16) fixed manifest drift for \`kubernetes_manifest.this\` (AppProject), but the sibling \`kubernetes_manifest.app\` (ArgoCD Application) still uses the plain shape and hits the same controller-mutation problem.

Concrete repro from \`8Fleet-LA/infra-terraform\`: prod apply since v0.4.0 fails on EVERY run with:

\`\`\`
Error: Provider produced inconsistent result after apply
When applying changes to module.argocd_projects[0].module.main[\"8fleet-dev\"].kubernetes_manifest.app,
provider \"registry.terraform.io/hashicorp/kubernetes\" produced an unexpected new value:
.object.operation.sync.revision: was null, but now cty.StringVal(\"c1426ecf5b808939c475fa732b568e9d8c3350a4\").
\`\`\`

Plus 5 more identical errors on \`spec.operation.sync.resources\`, \`spec.operation.sync.autoHealAttemptsCount\`, \`spec.operation.sync.prune\`, \`spec.operation.initiatedBy.automated\`, \`spec.operation.retry.limit\`.

Root cause: the ArgoCD application-controller writes to \`spec.operation.*\` within ~1s of the Application being created, between Terraform's apply call and its post-apply refresh.

## Fix

Mirror the AppProject pattern established in #15:

\`\`\`hcl
computed_fields = [
  \"metadata.annotations\",
  \"metadata.labels\",
  \"metadata.finalizers\",
  \"spec.operation\",
]

field_manager {
  force_conflicts = true
}
\`\`\`

\`spec.operation\` is the only Application-specific addition vs the AppProject fix — Application has no destinations/sourceRepos drift concern, so the controller-mutation surface is narrower than Project's.

## Non-breaking

- Rendered manifest matches byte-for-byte when no new inputs are set.
- Existing consumers re-applying after this fix will reconcile any drift the old behavior was crash-looping over. Most operations will be a no-op.

## Tag plan

After merge, please cut \`v1.4.3\`. Downstream \`8Fleet-LA/infra-terraform\` will bump from a temporary fork tag (\`v1.4.2-8fleet.1\`) back to the registry version.